### PR TITLE
zt/setup rubocop 0 36

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,7 @@
+inherit_from:
+  - lib/modified_cops.yml
+  - lib/disabled_cops.yml
+
+AllCops:
+  RunRailsCops: true
+  DisplayCopNames: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,5 +3,6 @@ inherit_from:
   - lib/disabled_cops.yml
 
 AllCops:
-  RunRailsCops: true
   DisplayCopNames: true
+Rails:
+  Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 # Specify your gem's dependencies in mad_rubocop.gemspec
 gemspec

--- a/README.md
+++ b/README.md
@@ -18,6 +18,15 @@ Or install it yourself as:
 
     $ gem install mad_rubocop
 
+Add this to your project .rubocop.yml file:
+
+```yml
+inherit_gem:
+  mad_rubocop: .rubocop.yml
+```
+
+NOTE: The `Exlude` setting on cops that only ignore certain files or directories cannot be set by MadRubocop.
+
 
 ## Development
 

--- a/lib/disabled_cops.yml
+++ b/lib/disabled_cops.yml
@@ -18,6 +18,8 @@ Metrics/ParameterLists:
 Metrics/PerceivedComplexity:
   Enabled: false
 
+Performance/Casecmp:
+  Enabled: false
 Performance/Detect:
   Enabled: false
 Performance/StringReplacement:
@@ -46,7 +48,7 @@ Style/EachWithObject:
   Enabled: false
 Style/Encoding:
   Enabled: false
-Style/ExtraSpacing: # do we want this cop disabled?
+Style/ExtraSpacing:
   Enabled: false
 Style/FirstArrayElementLineBreak:
   Enabled: false
@@ -74,6 +76,8 @@ Style/OptionHash:
   Enabled: false
 Style/PredicateName:
   Enabled: false
+Style/RedundantParentheses:
+  Enabled: false
 Style/RedundantSelf:
   Enabled: false
 Style/RegexpLiteral:
@@ -90,7 +94,11 @@ Style/StructInheritance:
   Enabled: false
 Style/SymbolArray:
   Enabled: false
-Style/TrailingComma:
+Style/TrailingCommaInArguments:
+  Enabled: false
+Style/TrailingCommaInLiteral:
+  Enabled: false
+Style/UnneededInterpolation:
   Enabled: false
 Style/WordArray:
   Enabled: false

--- a/lib/disabled_cops.yml
+++ b/lib/disabled_cops.yml
@@ -1,0 +1,96 @@
+---
+Metrics/AbcSize:
+  Enabled: false
+Metrics/BlockNesting:
+  Enabled: false
+Metrics/ClassLength:
+  Enabled: false
+Metrics/CyclomaticComplexity:
+  Enabled: false
+Metrics/LineLength:
+  Enabled: false
+Metrics/MethodLength:
+  Enabled: false
+Metrics/ModuleLength:
+  Enabled: false
+Metrics/ParameterLists:
+  Description: Avoid parameter lists longer than three or four parameters.
+Metrics/PerceivedComplexity:
+  Enabled: false
+
+Performance/Detect:
+  Enabled: false
+Performance/StringReplacement:
+  Enabled: false
+
+Rails/ActionFilter:
+  Enabled: false
+Rails/Date:
+  Enabled: false
+Rails/FindBy:
+  Enabled: false
+Rails/TimeZone:
+  Enabled: false
+
+Style/AutoResourceCleanup:
+  Enabled: false
+Style/CollectionMethods:
+  Enabled: false
+Style/Copyright:
+  Enabled: false
+Style/Documentation:
+  Enabled: false
+Style/DoubleNegation:
+  Enabled: false
+Style/EachWithObject:
+  Enabled: false
+Style/Encoding:
+  Enabled: false
+Style/ExtraSpacing: # do we want this cop disabled?
+  Enabled: false
+Style/FirstArrayElementLineBreak:
+  Enabled: false
+Style/FirstHashElementLineBreak:
+  Enabled: false
+Style/FirstMethodArgumentLineBreak:
+  Enabled: false
+Style/FirstMethodParameterLineBreak:
+  Enabled: false
+Style/FormatString:
+  Enabled: false
+Style/InlineComment:
+  Enabled: false
+Style/Lambda:
+  Enabled: false
+Style/MethodCalledOnDoEndBlock:
+  Enabled: false
+Style/MissingElse:
+  Enabled: false
+Style/MutableConstant:
+  Enabled: false
+Style/Next:
+  Enabled: false
+Style/OptionHash:
+  Enabled: false
+Style/PredicateName:
+  Enabled: false
+Style/RedundantSelf:
+  Enabled: false
+Style/RegexpLiteral:
+  Enabled: false
+Style/Send:
+  Enabled: false
+Style/SignalException:
+  Enabled: false
+Style/SingleLineBlockParams:
+  Enabled: false
+Style/StringMethods:
+  Enabled: false
+Style/StructInheritance:
+  Enabled: false
+Style/SymbolArray:
+  Enabled: false
+Style/TrailingComma:
+  Enabled: false
+Style/WordArray:
+  Enabled: false

--- a/lib/modified_cops.yml
+++ b/lib/modified_cops.yml
@@ -2,6 +2,10 @@
 # Cops that enforce a non RuboCop default style
 #
 
+Style/Alias:
+  Description: Use alias_method instead of alias in a class or module body.
+  EnforcedStyle: prefer_alias_method
+
 Style/AccessModifierIndentation:
   Description: Indent private/protected/public as deep as method definitions
   Enabled: true

--- a/lib/modified_cops.yml
+++ b/lib/modified_cops.yml
@@ -1,0 +1,19 @@
+##
+# Cops that enforce a non RuboCop default style
+#
+
+Style/AccessModifierIndentation:
+  Description: Indent private/protected/public as deep as method definitions
+  Enabled: true
+  EnforcedStyle: outdent
+
+Style/HashSyntax:
+  Description: 'Prefer Ruby 1.8 hash syntax { :a => 1, :b => 2 } over 1.9 syntax {
+    a: 1, b: 2 }.'
+  Enabled: true
+  EnforcedStyle: hash_rockets
+
+Style/StringLiterals:
+  Description: Checks if uses of quotes match the configured preference.
+  Enabled: true
+  EnforcedStyle: double_quotes

--- a/mad_rubocop.gemspec
+++ b/mad_rubocop.gemspec
@@ -1,7 +1,7 @@
 # coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'mad_rubocop/version'
+require "mad_rubocop/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "mad_rubocop"
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   # Prevent pushing this gem to RubyGems.org by setting 'allowed_push_host', or
   # delete this section to allow pushing this gem to any host.
   if spec.respond_to?(:metadata)
-    spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com'"
+    spec.metadata["allowed_push_host"] = "TODO: Set to 'http://mygemserver.com'"
   else
     raise "RubyGems 2.0 or newer is required to protect against public gem pushes."
   end

--- a/mad_rubocop.gemspec
+++ b/mad_rubocop.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "rubocop", "~> 0.35.0"
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/mad_rubocop.gemspec
+++ b/mad_rubocop.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 0.35.0"
+  spec.add_dependency "rubocop", "~> 0.36.0"
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"
 end

--- a/mad_rubocop.gemspec
+++ b/mad_rubocop.gemspec
@@ -30,5 +30,4 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rubocop", "~> 0.35.0"
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
 end


### PR DESCRIPTION
Note: Branched off of https://github.com/mxenabled/mad_rubocop/pull/1

Updates the yml files to be compliant with RuboCop 0.36 and makes the necessary changes to the cops that we want to enforce.

@film42 @liveh2o @vintagepenguin @abrandoned 
