### PR TITLE
zt/rubocop 0 37

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,1 @@
 require "bundler/gem_tasks"
-

--- a/mad_rubocop.gemspec
+++ b/mad_rubocop.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 0.36.0"
+  spec.add_dependency "rubocop", "~> 0.37.0"
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"
 end


### PR DESCRIPTION
Fixes #6. Upgrades MadRubocop to 0.37.

// RFC @liveh2o @mmmries @vintagepenguin @film42 @fergmastaflex 
