### PR TITLE
update MadRubocop dependency to RuboCop 0.38

### DIFF
--- a/mad_rubocop.gemspec
+++ b/mad_rubocop.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 0.37.0"
+  spec.add_dependency "rubocop", "~> 0.38.0"
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"
 end


### PR DESCRIPTION
Fixes #8.

Update the MadRubocop dependency to be RuboCop 0.38. The cop changes are listed in issue #8.

//RFC @film42 @mmmries @vintagepenguin @liveh2o 
