### PR TITLE
Upgrade rubocop to 0.49.1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,5 +4,6 @@ inherit_from:
 
 AllCops:
   DisplayCopNames: true
+  TargetRailsVersion: 4.0
 Rails:
   Enabled: true

--- a/lib/disabled_cops.yml
+++ b/lib/disabled_cops.yml
@@ -1,4 +1,15 @@
 ---
+Layout/ExtraSpacing:
+  Enabled: false
+Layout/FirstArrayElementLineBreak:
+  Enabled: false
+Layout/FirstHashElementLineBreak:
+  Enabled: false
+Layout/FirstMethodArgumentLineBreak:
+  Enabled: false
+Layout/FirstMethodParameterLineBreak:
+  Enabled: false
+
 Metrics/AbcSize:
   Enabled: false
 Metrics/BlockNesting:
@@ -31,6 +42,8 @@ Rails/Date:
   Enabled: false
 Rails/FindBy:
   Enabled: false
+Rails/HttpPositionalArguments:
+  Enabled: false
 Rails/TimeZone:
   Enabled: false
 
@@ -48,17 +61,9 @@ Style/EachWithObject:
   Enabled: false
 Style/Encoding:
   Enabled: false
-Style/ExtraSpacing:
-  Enabled: false
-Style/FirstArrayElementLineBreak:
-  Enabled: false
-Style/FirstHashElementLineBreak:
-  Enabled: false
-Style/FirstMethodArgumentLineBreak:
-  Enabled: false
-Style/FirstMethodParameterLineBreak:
-  Enabled: false
 Style/FormatString:
+  Enabled: false
+Style/FrozenStringLiteralComment:
   Enabled: false
 Style/InlineComment:
   Enabled: false

--- a/lib/disabled_cops.yml
+++ b/lib/disabled_cops.yml
@@ -40,11 +40,21 @@ Performance/StringReplacement:
 
 Rails/ActionFilter:
   Enabled: false
+Rails/Blank:
+  Enabled: false
 Rails/Date:
+  Enabled: false
+Rails/DynamicFindBy:
   Enabled: false
 Rails/FindBy:
   Enabled: false
+Rails/FilePath:
+  Enabled: false
 Rails/TimeZone:
+  Enabled: false
+
+# The autocorrect for this will break YAML load when aliases present
+Security/YAMLLoad:
   Enabled: false
 
 Style/AutoResourceCleanup:
@@ -76,6 +86,8 @@ Style/MissingElse:
 Style/MutableConstant:
   Enabled: false
 Style/Next:
+  Enabled: false
+Style/NumericPredicate:
   Enabled: false
 Style/OptionHash:
   Enabled: false

--- a/lib/disabled_cops.yml
+++ b/lib/disabled_cops.yml
@@ -42,8 +42,6 @@ Rails/Date:
   Enabled: false
 Rails/FindBy:
   Enabled: false
-Rails/HttpPositionalArguments:
-  Enabled: false
 Rails/TimeZone:
   Enabled: false
 

--- a/lib/disabled_cops.yml
+++ b/lib/disabled_cops.yml
@@ -12,6 +12,8 @@ Layout/FirstMethodParameterLineBreak:
 
 Metrics/AbcSize:
   Enabled: false
+Metrics/BlockLength:
+  Enabled: false
 Metrics/BlockNesting:
   Enabled: false
 Metrics/ClassLength:

--- a/lib/modified_cops.yml
+++ b/lib/modified_cops.yml
@@ -20,3 +20,7 @@ Style/StringLiterals:
   Description: Checks if uses of quotes match the configured preference.
   Enabled: true
   EnforcedStyle: double_quotes
+
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'

--- a/lib/modified_cops.yml
+++ b/lib/modified_cops.yml
@@ -16,6 +16,16 @@ Style/HashSyntax:
   Enabled: true
   EnforcedStyle: hash_rockets
 
+Style/PercentLiteralDelimiters:
+  Enabled: true
+  PreferredDelimiters:
+    default: '()'
+    '%i':    '()'
+    '%I':    '()'
+    '%r':    '{}'
+    '%w':    '()'
+    '%W':    '()'
+
 Style/StringLiterals:
   Description: Checks if uses of quotes match the configured preference.
   Enabled: true

--- a/lib/modified_cops.yml
+++ b/lib/modified_cops.yml
@@ -1,15 +1,14 @@
 ##
 # Cops that enforce a non RuboCop default style
 #
+Layout/AccessModifierIndentation:
+  Description: Indent private/protected/public as deep as method definitions
+  Enabled: true
+  EnforcedStyle: outdent
 
 Style/Alias:
   Description: Use alias_method instead of alias in a class or module body.
   EnforcedStyle: prefer_alias_method
-
-Style/AccessModifierIndentation:
-  Description: Indent private/protected/public as deep as method definitions
-  Enabled: true
-  EnforcedStyle: outdent
 
 Style/HashSyntax:
   Description: 'Prefer Ruby 1.8 hash syntax { :a => 1, :b => 2 } over 1.9 syntax {

--- a/lib/modified_cops.yml
+++ b/lib/modified_cops.yml
@@ -20,7 +20,3 @@ Style/StringLiterals:
   Description: Checks if uses of quotes match the configured preference.
   Enabled: true
   EnforcedStyle: double_quotes
-
-Metrics/BlockLength:
-  Exclude:
-    - 'spec/**/*'

--- a/mad_rubocop.gemspec
+++ b/mad_rubocop.gemspec
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "mad_rubocop/version"
@@ -19,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 0.38.0"
+  spec.add_dependency "rubocop", "~> 0.49.1"
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"
 end


### PR DESCRIPTION
This brings the ruby parser up-to-date. New cops `Rails/HttpPositionalArguments` and `Style/FrozenStringLiteralComment` are disabled and some cop names were fixed.

@ztoolson @mmmries @liveh2o @brianstien 

Here are some samples of offense reports to give an idea of how much work we will need to do to upgrade:

__Note: I left `Rails/HttpPositionalArguments` enabled for these reports to show how wide-spread the fix would be. I think that enabling `Style/FrozenStringLiteralComment` would be okay since there is an auto-fix for it and it is only a ruby 3.0 compatibility comment.__

```
331  Rails/HttpPositionalArguments
272  Metrics/BlockLength
141  Style/StringLiterals
28   Layout/AlignParameters
22   Rails/Blank
12   Rails/ApplicationRecord
6    Style/EmptyMethod
4    Style/PercentLiteralDelimiters
3    Bundler/OrderedGems
3    Rails/SkipsModelValidations
2    Layout/IndentHeredoc
2    Layout/TrailingBlankLines
2    Security/JSONLoad
2    Style/EmptyCaseCondition
1    Layout/SpaceBeforeBlockBraces
1    Lint/ScriptPermission
1    Rails/ApplicationJob
1    Rails/FilePath
1    Rails/Present
1    Style/CommentAnnotation
1    Style/MethodMissing
--
837  Total
```

```
244  Rails/HttpPositionalArguments
42   Rails/DynamicFindBy
14   Rails/Blank
12   Rails/ApplicationRecord
12   Style/PercentLiteralDelimiters
10   Layout/SpaceBeforeBlockBraces
6    Style/EmptyMethod
6    Style/StringLiterals
4    Rails/FilePath
3    Style/ClassAndModuleChildren
3    Style/NumericPredicate
2    Layout/SpaceInsidePercentLiteralDelimiters
2    Rails/OutputSafety
2    Security/YAMLLoad
1    Bundler/OrderedGems
1    Layout/EmptyLinesAroundExceptionHandlingKeywords
1    Layout/IndentHeredoc
1    Layout/MultilineMethodCallBraceLayout
1    Layout/SpaceBeforeFirstArg
--
367  Total
```


```
694   Rails/HttpPositionalArguments
403   Style/StringLiterals
259   Metrics/BlockLength
66    Rails/Blank
58    Style/EmptyMethod
43    Style/PercentLiteralDelimiters
32    Rails/OutputSafety
21    Lint/AmbiguousBlockAssociation
12    Rails/ApplicationRecord
11    Layout/MultilineMethodCallBraceLayout
11    Rails/SkipsModelValidations
6     Style/VariableNumber
5     Layout/MultilineHashBraceLayout
5     Lint/UnifiedInteger
5     Rails/Present
4     Bundler/OrderedGems
4     Style/InverseMethods
4     Style/NumericPredicate
3     Layout/SpaceBeforeBlockBraces
3     Style/EmptyCaseCondition
3     Style/GuardClause
2     Layout/EmptyLinesAroundExceptionHandlingKeywords
2     Layout/SpaceAroundOperators
2     Layout/SpaceInsidePercentLiteralDelimiters
2     Style/MultilineIfModifier
1     Layout/IndentHeredoc
1     Layout/MultilineArrayBraceLayout
1     Lint/ScriptPermission
1     Lint/UnneededDisable
1     Performance/CompareWithBlock
1     Rails/DynamicFindBy
1     Rails/FilePath
1     Style/MultipleComparison
1     Style/RedundantReturn
--
1669  Total
```


