### PR TITLE
Prefer expanded methods for empty methods

### DIFF
--- a/lib/modified_cops.yml
+++ b/lib/modified_cops.yml
@@ -10,6 +10,9 @@ Style/Alias:
   Description: Use alias_method instead of alias in a class or module body.
   EnforcedStyle: prefer_alias_method
 
+Style/EmptyMethod:
+  EnforcedStyle: expanded
+
 Style/HashSyntax:
   Description: 'Prefer Ruby 1.8 hash syntax { :a => 1, :b => 2 } over 1.9 syntax {
     a: 1, b: 2 }.'


### PR DESCRIPTION
With this cop enabled:

```
def show; end`
```

With the new style:

```
def show
end
```

//RFC @mattnichols @film42