### PR TITLE
Wow, these cops are so bad

### DIFF
--- a/lib/disabled_cops.yml
+++ b/lib/disabled_cops.yml
@@ -17,10 +17,12 @@ Layout/FirstMethodParameterLineBreak:
   Enabled: false
 Layout/IndentHeredoc:
   Enabled: false
+
 Lint/AmbiguousBlockAssociation:
   Enabled: false
-
 Lint/BooleanSymbol:
+  Enabled: false
+Lint/DuplicateMethods:
   Enabled: false
 Lint/RedundantWithIndex:
   Enabled: false


### PR DESCRIPTION
It's not that they're bad, it's that they don't work.

If you have an `attr_accessor` and then override the getter, it's a duplicate.

cc @liveh2o @brianstien 