### PR TITLE
Upgrade to rubocop ~> 0.6.2

### DIFF
--- a/lib/disabled_cops.yml
+++ b/lib/disabled_cops.yml
@@ -183,7 +183,9 @@ Style/SymbolArray:
   Enabled: false
 Style/TrailingCommaInArguments:
   Enabled: false
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
+  Enabled: false
+Style/TrailingCommaInHashLiteral:
   Enabled: false
 Style/TrailingUnderscoreVariable:
   Enabled: false

--- a/mad_rubocop.gemspec
+++ b/mad_rubocop.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 0.52.1"
+  spec.add_dependency "rubocop", "~> 0.62"
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"
 end


### PR DESCRIPTION
The impetus for this change is to allow rubocop to fix FactoryBot deprecation
warnings.