### PR TITLE
Upgrade rubocop to 0.81 to support ruby 2.7

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,7 @@
+require:
+  - rubocop-rails
+  - rubocop-performance
+
 inherit_from:
   - lib/modified_cops.yml
   - lib/disabled_cops.yml

--- a/lib/disabled_cops.yml
+++ b/lib/disabled_cops.yml
@@ -5,7 +5,7 @@ Bundler/InsecureProtocolSource:
 Gemspec/OrderedDependencies:
   Enabled: false
 
-Layout/AlignHash:
+Layout/HashAlignment:
   Enabled: false
 Layout/ClosingHeredocIndentation:
   Enabled: false
@@ -23,9 +23,9 @@ Layout/FirstMethodArgumentLineBreak:
   Enabled: false
 Layout/FirstMethodParameterLineBreak:
   Enabled: false
-Layout/IndentHeredoc:
+Layout/HeredocIndentation:
   Enabled: false
-Layout/LeadingBlankLines:
+Layout/LeadingEmptyLines:
   Enabled: false
 
 Lint/AmbiguousBlockAssociation:
@@ -42,9 +42,9 @@ Lint/ReturnInVoidContext:
   Enabled: false
 Lint/ScriptPermission:
   Enabled: false
-Lint/UnneededCopDisableDirective:
+Lint/RedundantCopDisableDirective:
   Enabled: false
-Lint/UnneededRequireStatement:
+Lint/RedundantRequireStatement:
   Enabled: false
 Lint/UriEscapeUnescape:
   Enabled: false
@@ -78,7 +78,7 @@ Naming/MemoizedInstanceVariableName:
   Enabled: false
 Naming/PredicateName:
   Enabled: false
-Naming/UncommunicativeMethodParamName:
+Naming/MethodParameterName:
   Enabled: false
 Naming/VariableNumber:
   Enabled: false
@@ -221,9 +221,9 @@ Style/TrailingCommaInHashLiteral:
   Enabled: false
 Style/TrailingUnderscoreVariable:
   Enabled: false
-Style/UnneededCondition:
+Style/RedundantCondition:
   Enabled: false
-Style/UnneededInterpolation:
+Style/RedundantInterpolation:
   Enabled: false
 Style/WordArray:
   Enabled: false

--- a/mad_rubocop.gemspec
+++ b/mad_rubocop.gemspec
@@ -21,6 +21,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rubocop", ">= 0.64.0"
+  spec.add_dependency "rubocop-performance"
+  spec.add_dependency "rubocop-rails"
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"
 end

--- a/mad_rubocop.gemspec
+++ b/mad_rubocop.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", ">= 0.64.0"
+  spec.add_dependency "rubocop", "~> 0.81.0"
   spec.add_dependency "rubocop-performance"
   spec.add_dependency "rubocop-rails"
   spec.add_development_dependency "bundler", "~> 2.0"

--- a/mad_rubocop.gemspec
+++ b/mad_rubocop.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 0.64.0"
+  spec.add_dependency "rubocop", ">= 0.64.0"
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"
 end


### PR DESCRIPTION
In the internal docs repo, we are iterating on v2 which uses rails 6 and ruby 2.7. Unfortunately rubocop version 0.64 does not support ruby 2.7. This MR adds changes to upgrade to robocop 0.81:
- Cop name changes
- Rails and Perf cops pulled out to separate gems since, added `rubocop-rails` and `rubocop-performance`