### PR TITLE
Rc upgrade rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,7 @@
+require:
+  - rubocop-rails
+  - rubocop-performance
+
 inherit_from:
   - lib/modified_cops.yml
   - lib/disabled_cops.yml

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,5 +8,6 @@ inherit_from:
 
 AllCops:
   DisplayCopNames: true
+  NewCops: disable
 Rails:
   Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,5 @@ inherit_from:
 
 AllCops:
   DisplayCopNames: true
-  TargetRailsVersion: 4.0
 Rails:
   Enabled: true

--- a/lib/disabled_cops.yml
+++ b/lib/disabled_cops.yml
@@ -5,7 +5,7 @@ Bundler/InsecureProtocolSource:
 Gemspec/OrderedDependencies:
   Enabled: false
 
-Layout/AlignHash:
+Layout/HashAlignment:
   Enabled: false
 Layout/ClosingHeredocIndentation:
   Enabled: false
@@ -23,9 +23,9 @@ Layout/FirstMethodArgumentLineBreak:
   Enabled: false
 Layout/FirstMethodParameterLineBreak:
   Enabled: false
-Layout/IndentHeredoc:
+Layout/HeredocIndentation:
   Enabled: false
-Layout/LeadingBlankLines:
+Layout/LeadingEmptyLines:
   Enabled: false
 
 Lint/AmbiguousBlockAssociation:
@@ -42,9 +42,9 @@ Lint/ReturnInVoidContext:
   Enabled: false
 Lint/ScriptPermission:
   Enabled: false
-Lint/UnneededCopDisableDirective:
+Lint/RedundantCopDisableDirective:
   Enabled: false
-Lint/UnneededRequireStatement:
+Lint/RedundantRequireStatement:
   Enabled: false
 Lint/UriEscapeUnescape:
   Enabled: false
@@ -78,7 +78,7 @@ Naming/MemoizedInstanceVariableName:
   Enabled: false
 Naming/PredicateName:
   Enabled: false
-Naming/UncommunicativeMethodParamName:
+Naming/MethodParameterName:
   Enabled: false
 Naming/VariableNumber:
   Enabled: false
@@ -221,9 +221,9 @@ Style/TrailingCommaInHashLiteral:
   Enabled: false
 Style/TrailingUnderscoreVariable:
   Enabled: false
-Style/UnneededCondition:
+Style/RedundantCondition:
   Enabled: false
-Style/UnneededInterpolation:
+Style/RedundantInterpolation:
   Enabled: false
 Style/WordArray:
   Enabled: false

--- a/lib/disabled_cops.yml
+++ b/lib/disabled_cops.yml
@@ -5,13 +5,17 @@ Bundler/InsecureProtocolSource:
 Gemspec/OrderedDependencies:
   Enabled: false
 
-Layout/HashAlignment:
+Layout/BeginEndAlignment:
   Enabled: false
 Layout/ClosingHeredocIndentation:
   Enabled: false
 Layout/ClosingParenthesisIndentation:
   Enabled: false
 Layout/EmptyLineAfterGuardClause:
+  Enabled: false
+Layout/EmptyLinesAroundAttributeAccessor:
+  Enabled: false
+Layout/EmptyLinesAroundBlockBody:
   Enabled: false
 Layout/ExtraSpacing:
   Enabled: false
@@ -23,14 +27,34 @@ Layout/FirstMethodArgumentLineBreak:
   Enabled: false
 Layout/FirstMethodParameterLineBreak:
   Enabled: false
+Layout/HashAlignment:
+  Enabled: false
 Layout/HeredocIndentation:
   Enabled: false
 Layout/LeadingEmptyLines:
   Enabled: false
+Layout/RescueEnsureAlignment:
+  Enabled: false
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: false
 
 Lint/AmbiguousBlockAssociation:
   Enabled: false
+Lint/BinaryOperatorWithIdenticalOperands:
+  Enabled: false
 Lint/BooleanSymbol:
+  Enabled: false
+Lint/ConstantDefinitionInBlock:
+  Enabled: false
+Lint/DeprecatedOpenSSLConstant:
+  Enabled: false
+Lint/EmptyFile:
+  Enabled: false
+Lint/FloatComparison:
+  Enabled: false
+Lint/MissingSuper:
+  Enabled: false
+Lint/MixedRegexpCaptureTypes:
   Enabled: false
 Lint/NonDeterministicRequireOrder:
   Enabled: false
@@ -48,9 +72,13 @@ Lint/RedundantCopDisableDirective:
   Enabled: false
 Lint/RedundantRequireStatement:
   Enabled: false
+Lint/RedundantSafeNavigation:
+  Enabled: false
 Lint/SuppressedException:
   Enabled: false
 Lint/ToJSON:
+  Enabled: false
+Lint/UnreachableLoop:
   Enabled: false
 Lint/UriEscapeUnescape:
   Enabled: false
@@ -93,6 +121,8 @@ Naming/VariableNumber:
 
 Performance/Casecmp:
   Enabled: false
+Performance/Count:
+  Enabled: false
 Performance/DeletePrefix:
   Enabled: false
 Performance/DeleteSuffix:
@@ -132,11 +162,19 @@ Rails/HelperInstanceVariable:
   Enabled: false
 Rails/HttpStatus:
   Enabled: false
+Rails/InverseOf:
+  Enabled: false
 Rails/LexicallyScopedActionFilter:
   Enabled: false
 Rails/PluralizationGrammar:
   Enabled: false
 Rails/RakeEnvironment:
+  Enabled: false
+Rails/RedundantForeignKey:
+  Enabled: false
+Rails/RedundantReceiverInWithOptions:
+  Enabled: false
+Rails/ReversibleMigration:
   Enabled: false
 Rails/SkipsModelValidations:
   Enabled: false
@@ -151,7 +189,15 @@ Rails/UnknownEnv:
 Security/YAMLLoad:
   Enabled: false
 
+Style/AccessorGrouping:
+  Enabled: false
 Style/AutoResourceCleanup:
+  Enabled: false
+Style/CaseLikeIf:
+  Enabled: false
+Style/ClassEqualityComparison:
+  Enabled: false
+Style/CombinableLoops:
   Enabled: false
 Style/ConditionalAssignment:
   Enabled: false
@@ -173,23 +219,39 @@ Style/EachWithObject:
   Enabled: false
 Style/EmptyCaseCondition:
   Enabled: false
+Style/EmptyLiteral:
+  Enabled: false
 Style/Encoding:
   Enabled: false
 Style/ExpandPathArguments:
+  Enabled: false
+Style/ExplicitBlockArgument:
   Enabled: false
 Style/FloatDivision:
   Enabled: false
 Style/FormatString:
   Enabled: false
 Style/FormatStringToken:
-  EnforcedStyle: unannotated
+  Enabled: false
 Style/FrozenStringLiteralComment:
   Enabled: false
+Style/GlobalStdStream:
+  Enabled: false
 Style/GuardClause:
+  Enabled: false
+Style/HashAsLastArrayItem:
+  Enabled: false
+Style/HashEachMethods:
+  Enabled: false
+Style/HashLikeCase:
+  Enabled: false
+Style/HashTransformValues:
   Enabled: false
 Style/IfUnlessModifier:
   Enabled: false
 Style/InlineComment:
+  Enabled: false
+Style/KeywordParametersOrder:
   Enabled: false
 Style/Lambda:
   Enabled: false
@@ -209,15 +271,27 @@ Style/Next:
   Enabled: false
 Style/NumericPredicate:
   Enabled: false
+Style/OptionalBooleanParameter:
+  Enabled: false
 Style/OptionHash:
+  Enabled: false
+Style/RedundantAssignment:
   Enabled: false
 Style/RedundantConditional:
   Enabled: false
+Style/RedundantFileExtensionInRequire:
+  Enabled: false
 Style/RedundantParentheses:
+  Enabled: false
+Style/RedundantRegexpCharacterClass:
+  Enabled: false
+Style/RedundantRegexpEscape:
   Enabled: false
 Style/RedundantReturn:
   Enabled: false
 Style/RedundantSelf:
+  Enabled: false
+Style/RedundantSelfAssignment:
   Enabled: false
 Style/RegexpLiteral:
   Enabled: false
@@ -229,9 +303,17 @@ Style/Send:
   Enabled: false
 Style/SignalException:
   Enabled: false
+Style/SingleArgumentDig:
+  Enabled: false
 Style/SingleLineBlockParams:
   Enabled: false
+Style/SlicingWithRange:
+  Enabled: false
+Style/SoleNestedConditional:
+  Enabled: false
 Style/StderrPuts:
+  Enabled: false
+Style/StringConcatenation:
   Enabled: false
 Style/StringMethods:
   Enabled: false
@@ -247,9 +329,15 @@ Style/TrailingCommaInHashLiteral:
   Enabled: false
 Style/TrailingUnderscoreVariable:
   Enabled: false
+Style/RedundantBegin:
+  Enabled: false
 Style/RedundantCondition:
   Enabled: false
+Style/RedundantFetchBlock:
+  Enabled: false
 Style/RedundantInterpolation:
+  Enabled: false
+Style/UnpackFirst:
   Enabled: false
 Style/WordArray:
   Enabled: false

--- a/lib/disabled_cops.yml
+++ b/lib/disabled_cops.yml
@@ -32,6 +32,8 @@ Lint/AmbiguousBlockAssociation:
   Enabled: false
 Lint/BooleanSymbol:
   Enabled: false
+Lint/NonDeterministicRequireOrder:
+  Enabled: false
 Lint/RedundantWithIndex:
   Enabled: false
 Lint/RedundantWithObject:
@@ -45,6 +47,10 @@ Lint/ScriptPermission:
 Lint/RedundantCopDisableDirective:
   Enabled: false
 Lint/RedundantRequireStatement:
+  Enabled: false
+Lint/SuppressedException:
+  Enabled: false
+Lint/ToJSON:
   Enabled: false
 Lint/UriEscapeUnescape:
   Enabled: false
@@ -80,10 +86,16 @@ Naming/PredicateName:
   Enabled: false
 Naming/MethodParameterName:
   Enabled: false
+Naming/RescuedExceptionsVariableName:
+  Enabled: false
 Naming/VariableNumber:
   Enabled: false
 
 Performance/Casecmp:
+  Enabled: false
+Performance/DeletePrefix:
+  Enabled: false
+Performance/DeleteSuffix:
   Enabled: false
 Performance/Detect:
   Enabled: false
@@ -108,11 +120,15 @@ Rails/Date:
   Enabled: false
 Rails/DynamicFindBy:
   Enabled: false
+Rails/EnumHash:
+  Enabled: false
 Rails/FindBy:
   Enabled: false
 Rails/FilePath:
   Enabled: false
 Rails/HasManyOrHasOneDependent:
+  Enabled: false
+Rails/HelperInstanceVariable:
   Enabled: false
 Rails/HttpStatus:
   Enabled: false
@@ -120,9 +136,13 @@ Rails/LexicallyScopedActionFilter:
   Enabled: false
 Rails/PluralizationGrammar:
   Enabled: false
+Rails/RakeEnvironment:
+  Enabled: false
 Rails/SkipsModelValidations:
   Enabled: false
 Rails/TimeZone:
+  Enabled: false
+Rails/UniqueValidationWithoutIndex:
   Enabled: false
 Rails/UnknownEnv:
   Enabled: false
@@ -157,8 +177,12 @@ Style/Encoding:
   Enabled: false
 Style/ExpandPathArguments:
   Enabled: false
+Style/FloatDivision:
+  Enabled: false
 Style/FormatString:
   Enabled: false
+Style/FormatStringToken:
+  EnforcedStyle: unannotated
 Style/FrozenStringLiteralComment:
   Enabled: false
 Style/GuardClause:
@@ -176,6 +200,8 @@ Style/MinMax:
 Style/MissingElse:
   Enabled: false
 Style/MixinUsage:
+  Enabled: false
+Style/MultilineWhenThen:
   Enabled: false
 Style/MutableConstant:
   Enabled: false

--- a/lib/disabled_cops.yml
+++ b/lib/disabled_cops.yml
@@ -144,7 +144,15 @@ Rails/ActionFilter:
   Enabled: false
 Rails/ActiveRecordAliases:
   Enabled: false
+Rails/ApplicationJob:
+  Enabled: false
+Rails/ApplicationRecord:
+  Enabled: false
+Rails/BelongsTo:
+  Enabled: false
 Rails/Blank:
+  Enabled: false
+Rails/ContentTag:
   Enabled: false
 Rails/Date:
   Enabled: false
@@ -160,11 +168,17 @@ Rails/HasManyOrHasOneDependent:
   Enabled: false
 Rails/HelperInstanceVariable:
   Enabled: false
+Rails/HttpPositionalArguments:
+  Enabled: false
 Rails/HttpStatus:
+  Enabled: false
+Rails/IndexWith:
   Enabled: false
 Rails/InverseOf:
   Enabled: false
 Rails/LexicallyScopedActionFilter:
+  Enabled: false
+Rails/Pick:
   Enabled: false
 Rails/PluralizationGrammar:
   Enabled: false

--- a/lib/mad_rubocop/version.rb
+++ b/lib/mad_rubocop/version.rb
@@ -1,3 +1,3 @@
 module MadRubocop
-  VERSION = "3.64.0"
+  VERSION = "4.0.0.rc1"
 end

--- a/mad_rubocop.gemspec
+++ b/mad_rubocop.gemspec
@@ -20,9 +20,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 0.81.0"
-  spec.add_dependency "rubocop-performance", "~> 1.6.0"
-  spec.add_dependency "rubocop-rails", "~> 2.5.0"
+  spec.add_dependency "rubocop", "~> 1.0.0"
+  spec.add_dependency "rubocop-performance", "~> 1.10.0"
+  spec.add_dependency "rubocop-rails", "~> 2.9.0"
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"
 end

--- a/mad_rubocop.gemspec
+++ b/mad_rubocop.gemspec
@@ -21,6 +21,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rubocop", ">= 0.64.0"
+  spec.add_dependency "rubocop-performance"
+  spec.add_dependency "rubocop-rails"
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"
 end

--- a/mad_rubocop.gemspec
+++ b/mad_rubocop.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", ">= 0.64.0"
+  spec.add_dependency "rubocop", "~> 0.81.0"
   spec.add_dependency "rubocop-performance"
   spec.add_dependency "rubocop-rails"
   spec.add_development_dependency "bundler", "~> 2.0"

--- a/mad_rubocop.gemspec
+++ b/mad_rubocop.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 0.64.0"
+  spec.add_dependency "rubocop", ">= 0.64.0"
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"
 end

--- a/mad_rubocop.gemspec
+++ b/mad_rubocop.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rubocop", "~> 0.81.0"
-  spec.add_dependency "rubocop-performance"
-  spec.add_dependency "rubocop-rails"
+  spec.add_dependency "rubocop-performance", "~> 1.6.0"
+  spec.add_dependency "rubocop-rails", "~> 2.5.0"
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"
 end


### PR DESCRIPTION
This builds upon Ben Schinn's PR: https://github.com/mxenabled/mad_rubocop/pull/19

The first objective was to bring ruby 2.7 support to the gem.  After that, I opted to make the remaining jump to get rubocop to at least the 1.0 release.  FInally, I went through and tested this against several of our internal repositories and used that as a guide to disable newer cops in an attempt to minimize the impact this would have.  We ought to audit the list of disabled cops as there are several in here that I think are great ideas, but it would be better to roll them out more slowly.

As it stands, this will identify a few new things, but I think they're worth the minor hassle they'll produce:

* The rails environment comparison now detects `!=` checks and several of our services do this
* `Layout/SpaceBeforeFirstArg` is new, but I only found one violation so far and it seems worth bringing in
* `Lint/UselessMethodDefinition` is new, but also found one violation and it seemed like a good idea to bring in